### PR TITLE
Fixed toThrow so it doesn't always pass, and added check to make sure va...

### DIFF
--- a/expectations.js
+++ b/expectations.js
@@ -283,12 +283,21 @@
         this.assertions.fail('to be null');
     };
     Expect.prototype.toThrow = function(){
+        var threw = false;
+
+        if(typeof this.value !== 'function'){
+            return this.fail('to be a function');
+        }
+
         try{
             this.value();
-            this.fail('to throw an exception');
         }catch(e){
-            this.assertions.pass();
+            threw = true;
         }
+        if(!threw){
+            return this.fail('to throw an exception');
+        }
+        this.assertions.pass();
     };
     Expect.prototype.pass = function(){
         this.assertions.pass();

--- a/test/expect.tests.js
+++ b/test/expect.tests.js
@@ -211,14 +211,37 @@
                 }).toThrow();
             });
             it('throws when function does not throw', function(){
+                var error;
+
                 try{
                     expect(function(){
                         // All OK
                     }).toThrow();
                 }catch(err){
-                    if (err.message !== 'expected function (){} to throw an exception'){
-                        throw new Error('Expected error message is not correct: ' + err.message);
-                    }
+                    error = err;
+                }
+
+                if (error === undefined){
+                    throw new Error('Expected error was not thrown');
+                }
+                if (error.message !== 'expected function (){} to throw an exception'){
+                    throw new Error('Expected error message is not correct: ' + error.message);
+                }
+            });
+            it('throws when toThrow is called on a non-function', function(){
+                var error;
+
+                try{
+                    expect('bob').toThrow();
+                }catch(err){
+                    error = err;
+                }
+
+                if (error === undefined){
+                    throw new Error('Expected error was not thrown');
+                }
+                if (error.message !== 'expected "bob" to be a function'){
+                    throw new Error('Expected error message is not correct: ' + error.message);
                 }
             });
         });


### PR DESCRIPTION
...lue is a function.

@spmason I noticed that toThrow was always passing, regardless of whether or not the function passed in threw an error. The tests did not catch this as the checks were being made in the catch block

So when

`expect(function(){
                        // All OK
                    }).toThrow();
`

didn't throw an error, the catch block never got executed and the checks never got run.
