### PR TITLE
Add error message checking to toThrow

### DIFF
--- a/expectations.js
+++ b/expectations.js
@@ -287,20 +287,30 @@
         }
         this.assertions.fail('to be null');
     };
-    Expect.prototype.toThrow = function(){
-        var threw = false;
+    Expect.prototype.toThrow = function(error){
+        var errorMessage,
+            thrownError;
 
         if(typeof this.value !== 'function'){
             return this.fail('to be a function');
+        }
+        if(typeof error === 'string'){
+            errorMessage = error;
+        }
+        else if(error instanceof Error){
+            errorMessage = error.message;
         }
 
         try{
             this.value();
         }catch(e){
-            threw = true;
+            thrownError = e;
         }
-        if(!threw){
+        if(!thrownError){
             return this.fail('to throw an exception');
+        }
+        if(errorMessage && thrownError.message !== errorMessage){
+            return this.fail('to throw', errorMessage);
         }
         this.assertions.pass();
     };

--- a/test/expect.tests.js
+++ b/test/expect.tests.js
@@ -262,6 +262,42 @@
                     throw new Error('Expected error message is not correct: ' + error.message);
                 }
             });
+            it('throws when parameterized Error message does not match the thrown Error message', function(){
+                var error;
+
+                try{
+                    expect(function(){
+                        throw new Error('I don\'t match');
+                    }).toThrow(new Error('the provided error'));
+                }catch(err){
+                    error = err;
+                }
+
+                if (error === undefined){
+                    throw new Error('Expected error was not thrown');
+                }
+                if (error.message !== 'expected function (){} to throw "the provided error"'){
+                    throw new Error('Expected error message is not correct: ' + error.message);
+                }
+            });
+            it('throws when parameterized string does not match the thrown Error messsage', function(){
+                var error;
+
+                try{
+                    expect(function(){
+                        throw new Error('I don\'t match');
+                    }).toThrow('the provided string');
+                }catch(err){
+                    error = err;
+                }
+
+                if (error === undefined){
+                    throw new Error('Expected error was not thrown');
+                }
+                if (error.message !== 'expected function (){} to throw "the provided string"'){
+                    throw new Error('Expected error message is not correct: ' + error.message);
+                }
+            });
         });
 
         describe('toBeNull', function(){


### PR DESCRIPTION
Hi Steve, I've found when using expectations, I expect to be able to provide an Error or error message to `toThrow` and for the expectation to fail if it doesn't match the thrown error, so I thought I'd add that functionality.

Feedback hotly anticipated. Cheers!
