### PR TITLE
Increase error output stack depth to 10 from 5

### DIFF
--- a/expectations.js
+++ b/expectations.js
@@ -52,7 +52,7 @@
         }
         if(value instanceof Array){
             var mapped = [];
-            if(!isOnStack(value, stack) && stack.length < 5){
+            if(!isOnStack(value, stack) && stack.length < 10){
                 for(var i = 0; i < value.length; i++){
                     mapped.push(formatValue(value[i], false, stack));
                     stack.push(value[i]);
@@ -66,7 +66,7 @@
             return '<' + value.nodeName.toLowerCase() + ' />';
         }
 
-        if(typeof value === 'object' && stack.length < 5){
+        if(typeof value === 'object' && stack.length < 10){
             if(value.toString() !== '[object Object]'){
                 if(value instanceof Error){
                     return '[Error: ' + value.toString() + ']';

--- a/test/expect.tests.js
+++ b/test/expect.tests.js
@@ -397,16 +397,28 @@
                         a: {
                             b: {
                                 c: {
-                                    d: nested
+                                    d: {
+                                        e: {
+                                            f: {
+                                                g: {
+                                                    h: {
+                                                        i: nested
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
                                 }
                             }
                         }
                     };
-                nested.e = obj;
+                nested.j = obj;
                 try{
                     expect(obj).not.toBeDefined();
                 }catch(err){
-                    if(err.message !== 'expected {"a": {"b": {"c": {"d": {"e": [object Object]}}}}} not to be defined'){
+                    if(err.message !==
+                        'expected {"a": {"b": {"c": {"d": {"e": {"f": {"g": {"h": {"i": {"j": [object Object]}}}}}}}}}} not to be defined'
+                        ){
                         throw new Error('Expected error message is not correct: ' + err.message);
                     }
                 }
@@ -417,16 +429,28 @@
                         a: {
                             b: {
                                 c: {
-                                    d: nested
+                                    d: {
+                                        e: {
+                                            f: {
+                                                g: {
+                                                    h: {
+                                                        i: nested
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
                                 }
                             }
                         }
                     };
-                nested.e = [obj];
+                nested.j = [obj];
                 try{
                     expect(obj).not.toBeDefined();
                 }catch(err){
-                    if(err.message !== 'expected {"a": {"b": {"c": {"d": {"e": [[object Object]]}}}}} not to be defined'){
+                    if(err.message !==
+                        'expected {"a": {"b": {"c": {"d": {"e": {"f": {"g": {"h": {"i": {"j": [[object Object]]}}}}}}}}}} not to be defined'
+                        ){
                         throw new Error('Expected error message is not correct: ' + err.message);
                     }
                 }


### PR DESCRIPTION
Found 5 a little restrictive for array matching. 

Maintaining style resulted in a lot of lines creating test objects - happy to rebase into `{"a": {"b": {"c": {"d": {"e": {"f": {"g": {"h": {"i": {"j": nested}}}}}}}}}}` format if you'd prefer. Also tried to maintain column width - will change if desired.

Thanks.
