### PR TITLE
toBeNull and Date test

### DIFF
--- a/expectations.js
+++ b/expectations.js
@@ -282,10 +282,11 @@
         this.assertions.fail(message);
     };
     Expect.prototype.toBeNull = function(){
+        var message = this.generateMessage(this.value, this.expr, 'to be null');
         if(this.value === null){
-            return this.assertions.pass();
+            return this.assertions.pass(message);
         }
-        this.assertions.fail('to be null');
+        this.assertions.fail(message);
     };
     Expect.prototype.toThrow = function(error){
         var errorMessage,

--- a/test/expect.tests.js
+++ b/test/expect.tests.js
@@ -494,7 +494,7 @@
             });
             it('can generate correct message for Dates', function(){
                 try{
-                    expect(new Date(2012, 0, 1)).not.toBeDefined();
+                    expect(new Date(Date.UTC(2012, 0, 1))).not.toBeDefined();
                 }catch(err){
                     if(err.message !== 'expected [Date Sun, 01 Jan 2012 00:00:00 GMT] not to be defined'){
                         throw new Error('Expected error message is not correct: ' + err.message);

--- a/test/expect.tests.js
+++ b/test/expect.tests.js
@@ -316,7 +316,7 @@
             });
             it('throws when expects non-null values toBeNull', function(){
                 try{
-                    expect('abc').toBeDefined();
+                    expect('abc').toBeNull();
                 }catch(err){
                     if (err.message !== 'expected "abc" to be null'){
                         throw new Error('Expected error message is not correct: ' + err.message);


### PR DESCRIPTION
This fixes the error message of `toBeNull`. A test case was already included but flawed (using `toBeDefined` in place of `toBeNull`). This is now fixed, too.

The second commit fixes an issue with a test case failing when the developer's time zone is not GMT. For example, in CET, `new Date(2012, 0, 1).toUTCString()` is "Sat, 31 Dec 2011 23:00:00 GMT". Fixed using UTC timestamp for constructor.