### PR TITLE
Caller-supplied custom failure messages

### DIFF
--- a/expectations.js
+++ b/expectations.js
@@ -195,60 +195,66 @@
      * expr: An optional expression to pivot on, eg "not"
      * toDo: What the value was expected to do - eg "to equal", "to be defined" etc
      * otherVal: Optionally give the value you're comparing against at the end of the message
+     * customMsg: An optional custom message to include
     **/
-    Expect.prototype.generateMessage = function(value, expr, toDo, otherVal){
-        return ('expected ' + formatValue(value) + ' ' + expr + toDo + ' ' + formatValue(otherVal, true)).replace(/\s\s/g, ' ').replace(/(^\s|\s$)/g, '');
+    Expect.prototype.generateMessage = function(value, expr, toDo, otherVal, customMsg){
+        var message = ('expected ' + formatValue(value) + ' ' + expr + toDo + ' ' + formatValue(otherVal, true)).replace(/\s\s/g, ' ').replace(/(^\s|\s$)/g, '');
+
+        if (customMsg) {
+            return customMsg + ': ' + message;
+        }
+        return message;
     };
 
-    Expect.prototype.toEqual = function(val){
-        var message = this.generateMessage(this.value, this.expr, 'to equal', val);
+    Expect.prototype.toEqual = function(val, customMsg){
+        var message = this.generateMessage(this.value, this.expr, 'to equal', val, customMsg);
 
         if(!eq(this.value, val, [])){
             return this.assertions.fail(message);
         }
         this.assertions.pass(message);
     };
-    Expect.prototype.toNotEqual = function(value){
-        return this.not.toEqual(value);
+    Expect.prototype.toNotEqual = function(value, customMsg){
+        return this.not.toEqual(value, customMsg);
     };
-    Expect.prototype.toBe = function(val){
-        var message = this.generateMessage(this.value, this.expr, 'to equal', val);
+    Expect.prototype.toBe = function(val, customMsg){
+        var message = this.generateMessage(this.value, this.expr, 'to equal', val, customMsg);
         if(this.value !== val){
             return this.assertions.fail(message);
         }
         this.assertions.pass(message);
     };
-    Expect.prototype.toBeTruthy = function(val){
-        var message = this.generateMessage(this.value, this.expr, 'to be truthy');
+    Expect.prototype.toBeTruthy = function(customMsg){
+        var message = this.generateMessage(this.value, this.expr, 'to be truthy', undefined, customMsg);
         if(!!this.value){
             return this.assertions.pass(message);
         }
         this.assertions.fail(message);
     };
-    Expect.prototype.toBeFalsey = Expect.prototype.toBeFalsy = function(val){
-        var message = this.generateMessage(this.value, this.expr, 'to be falsey');
+    Expect.prototype.toBeFalsey = Expect.prototype.toBeFalsy = function(customMsg){
+        var message = this.generateMessage(this.value, this.expr, 'to be falsey', undefined, customMsg);
         if(!this.value){
             return this.assertions.pass(message);
         }
         this.assertions.fail(message);
     };
-    Expect.prototype.toBeGreaterThan = function(val){
-        var message = this.generateMessage(this.value, this.expr, 'to be greater than', val);
+    Expect.prototype.toBeGreaterThan = function(val, customMsg){
+        var message = this.generateMessage(this.value, this.expr, 'to be greater than', val, customMsg);
         if(this.value > val){
             return this.assertions.pass(message);
         }
         this.assertions.fail(message);
     };
-    Expect.prototype.toBeLessThan = function(val){
-        var message = this.generateMessage(this.value, this.expr, 'to be less than', val);
+    Expect.prototype.toBeLessThan = function(val, customMsg){
+        var message = this.generateMessage(this.value, this.expr, 'to be less than', val, customMsg);
         if(this.value < val){
             return this.assertions.pass(message);
         }
         this.assertions.fail(message);
     };
-    Expect.prototype.toContain = function(val){
+    Expect.prototype.toContain = function(val, customMsg){
         var i,
-            message = this.generateMessage(this.value, this.expr, 'to contain', val);
+            message = this.generateMessage(this.value, this.expr, 'to contain', val, customMsg);
 
         if(this.value.indexOf(val) > -1){
             return this.assertions.pass(message);
@@ -260,35 +266,35 @@
         }
         this.assertions.fail(message);
     };
-    Expect.prototype.toMatch = function(regex){
-        var message = this.generateMessage(this.value, this.expr, 'to match', regex);
+    Expect.prototype.toMatch = function(regex, customMsg){
+        var message = this.generateMessage(this.value, this.expr, 'to match', regex, customMsg);
         if(regex.test(this.value)){
             return this.assertions.pass(message);
         }
         return this.assertions.fail(message);
     };
-    Expect.prototype.toBeDefined = function(){
-        var message = this.generateMessage(this.value, this.expr, 'to be defined');
+    Expect.prototype.toBeDefined = function(customMsg){
+        var message = this.generateMessage(this.value, this.expr, 'to be defined', undefined, customMsg);
         if(typeof this.value !== 'undefined'){
             return this.assertions.pass(message);
         }
         this.assertions.fail(message);
     };
-    Expect.prototype.toBeUndefined = function(){
-        var message = this.generateMessage(this.value, this.expr, 'to be undefined');
+    Expect.prototype.toBeUndefined = function(customMsg){
+        var message = this.generateMessage(this.value, this.expr, 'to be undefined', undefined, customMsg);
         if(typeof this.value === 'undefined'){
             return this.assertions.pass(message);
         }
         this.assertions.fail(message);
     };
-    Expect.prototype.toBeNull = function(){
-        var message = this.generateMessage(this.value, this.expr, 'to be null');
+    Expect.prototype.toBeNull = function(customMsg){
+        var message = this.generateMessage(this.value, this.expr, 'to be null', undefined, customMsg);
         if(this.value === null){
             return this.assertions.pass(message);
         }
         this.assertions.fail(message);
     };
-    Expect.prototype.toThrow = function(error){
+    Expect.prototype.toThrow = function(error, customMsg){
         var errorMessage,
             thrownError;
 
@@ -308,18 +314,18 @@
             thrownError = e;
         }
         if(!thrownError){
-            return this.fail('to throw an exception');
+            return this.fail('to throw an exception', undefined, customMsg);
         }
         if(errorMessage && thrownError.message !== errorMessage){
-            return this.fail('to throw', errorMessage);
+            return this.fail('to throw', errorMessage, customMsg);
         }
         this.assertions.pass();
     };
     Expect.prototype.pass = function(){
         this.assertions.pass();
     };
-    Expect.prototype.fail = function(why, what){
-        var message = this.generateMessage(this.value, this.expr, why || '', what);
+    Expect.prototype.fail = function(why, what, customMsg){
+        var message = this.generateMessage(this.value, this.expr, why || '', what, customMsg);
 
         this.assertions.fail(message);
     };

--- a/test/expect.tests.js
+++ b/test/expect.tests.js
@@ -66,6 +66,15 @@
                     }
                 }
             });
+            it('supports custom messages', function(){
+                try {
+                    expect(true).toEqual(false, 'A custom error');
+                }catch(err){
+                    if(err.message !== 'A custom error: expected true to equal false') {
+                        throw new Error('Expected error message is not correct: ' + err.message);
+                    }
+                }
+            });
         });
 
         describe('toNotEqual', function(){
@@ -77,6 +86,15 @@
                     expect(true).toNotEqual(true);
                 }catch(err){
                     if(err.message !== 'expected true not to equal true'){
+                        throw new Error('Expected error message is not correct: ' + err.message);
+                    }
+                }
+            });
+            it('supports custom messages', function(){
+                try {
+                    expect(true).toNotEqual(true, 'A custom error');
+                }catch(err){
+                    if(err.message !== 'A custom error: expected true not to equal true') {
                         throw new Error('Expected error message is not correct: ' + err.message);
                     }
                 }
@@ -98,6 +116,15 @@
                     }
                 }
             });
+            it('supports custom messages', function(){
+                try {
+                    expect(obj1).toBe(obj2, 'A custom error');
+                }catch(err){
+                    if(err.message !== 'A custom error: expected {"abc": 123} to equal {"abc": 123}'){
+                        throw new Error('Expected error message is not correct: ' + err.message);
+                    }
+                }
+            });
         });
 
         describe('toMatch', function(){
@@ -113,6 +140,15 @@
                     }
                 }
             });
+            it('supports custom messages', function(){
+                try {
+                    expect('abc').toMatch(/d/, 'A custom error');
+                }catch(err){
+                    if(err.message !== 'A custom error: expected "abc" to match /d/'){
+                        throw new Error('Expected error message is not correct: ' + err.message);
+                    }
+                }
+            });
         });
 
         describe('toBeTruthy', function(){
@@ -124,6 +160,15 @@
                     expect('').toBeTruthy();
                 }catch(err){
                     if (err.message !== 'expected "" to be truthy'){
+                        throw new Error('Expected error message is not correct: ' + err.message);
+                    }
+                }
+            });
+            it('supports custom messages', function(){
+                try{
+                    expect('').toBeTruthy('A custom error');
+                }catch(err){
+                    if (err.message !== 'A custom error: expected "" to be truthy'){
                         throw new Error('Expected error message is not correct: ' + err.message);
                     }
                 }
@@ -155,6 +200,15 @@
                     }
                 }
             });
+            it('supports custom messages', function(){
+                try{
+                    expect([1, 2, 3, 4]).toContain(5, 'A custom error');
+                }catch(err){
+                    if (err.message !== 'A custom error: expected [1, 2, 3, 4] to contain 5'){
+                        throw new Error('Expected error message is not correct: ' + err.message);
+                    }
+                }
+            });
         });
 
         describe('toBeFalsy', function(){
@@ -166,6 +220,15 @@
                     expect('abc').toBeFalsy();
                 }catch(err){
                     if (err.message !== 'expected "abc" to be falsey'){
+                        throw new Error('Expected error message is not correct: ' + err.message);
+                    }
+                }
+            });
+            it('supports custom messages', function(){
+                try{
+                    expect('abc').toBeFalsy('A custom error');
+                }catch(err){
+                    if (err.message !== 'A custom error: expected "abc" to be falsey'){
                         throw new Error('Expected error message is not correct: ' + err.message);
                     }
                 }
@@ -185,6 +248,15 @@
                     }
                 }
             });
+            it('supports custom messages', function(){
+                try{
+                    expect(0).toBeGreaterThan(1, 'A custom error');
+                }catch(err){
+                    if (err.message !== 'A custom error: expected 0 to be greater than 1'){
+                        throw new Error('Expected error message is not correct: ' + err.message);
+                    }
+                }
+            });
         });
 
         describe('toBeLessThan', function(){
@@ -196,6 +268,15 @@
                     expect(1).toBeLessThan(0);
                 }catch(err){
                     if (err.message !== 'expected 1 to be less than 0'){
+                        throw new Error('Expected error message is not correct: ' + err.message);
+                    }
+                }
+            });
+            it('supports custom messages', function(){
+                try{
+                    expect(1).toBeLessThan(0, 'A custom error');
+                }catch(err){
+                    if (err.message !== 'A custom error: expected 1 to be less than 0'){
                         throw new Error('Expected error message is not correct: ' + err.message);
                     }
                 }
@@ -215,6 +296,15 @@
                     }
                 }
             });
+            it('supports custom messages', function(){
+                try{
+                    expect(undefined).toBeDefined('A custom error');
+                }catch(err){
+                    if (err.message !== 'A custom error: expected undefined to be defined'){
+                        throw new Error('Expected error message is not correct: ' + err.message);
+                    }
+                }
+            });
         });
 
         describe('toBeUndefined', function(){
@@ -226,6 +316,15 @@
                     expect({}).toBeUndefined();
                 }catch(err){
                     if (err.message !== 'expected {} to be undefined'){
+                        throw new Error('Expected error message is not correct: ' + err.message);
+                    }
+                }
+            });
+            it('supports custom messages', function(){
+                try{
+                    expect({}).toBeUndefined('A custom error');
+                }catch(err){
+                    if (err.message !== 'A custom error: expected {} to be undefined'){
                         throw new Error('Expected error message is not correct: ' + err.message);
                     }
                 }
@@ -308,6 +407,24 @@
                     throw new Error('Expected error message is not correct: ' + error.message);
                 }
             });
+            it('supports custom messages', function(){
+                var error;
+
+                try{
+                    expect(function(){
+                        throw new Error('I don\'t match');
+                    }).toThrow('the provided string', 'A custom error');
+                }catch(err){
+                    error = err;
+                }
+
+                if (error === undefined){
+                    throw new Error('Expected error was not thrown');
+                }
+                if (error.message !== 'A custom error: expected function (){} to throw "the provided string"'){
+                    throw new Error('Expected error message is not correct: ' + error.message);
+                }
+            });
         });
 
         describe('toBeNull', function(){
@@ -319,6 +436,15 @@
                     expect('abc').toBeNull();
                 }catch(err){
                     if (err.message !== 'expected "abc" to be null'){
+                        throw new Error('Expected error message is not correct: ' + err.message);
+                    }
+                }
+            });
+            it('supports custom messages', function(){
+                try{
+                    expect('abc').toBeNull('A custom error');
+                }catch(err){
+                    if (err.message !== 'A custom error: expected "abc" to be null'){
                         throw new Error('Expected error message is not correct: ' + err.message);
                     }
                 }


### PR DESCRIPTION
This change allows callers to provide their own failure messages, as in Jasmine. Caller-supplied failure messages make it easier to work with specs that expect multiple things.