### PR TITLE
Added matcher toBeCloseTo

### DIFF
--- a/expectations.js
+++ b/expectations.js
@@ -321,6 +321,16 @@
         }
         this.assertions.pass();
     };
+    Expect.prototype.toBeCloseTo = function(val, precision, customMsg){
+        var message = this.generateMessage(this.value, this.expr, 'to be close to', val, customMsg);
+        if (precision !== 0) {
+            precision = precision || 2;
+        }
+        if(Math.abs(val - this.value) < Math.pow(10, -precision) / 2){
+            return this.assertions.pass(message);
+        }
+        this.assertions.fail(message);
+    },
     Expect.prototype.pass = function(){
         this.assertions.pass();
     };

--- a/test/expect.tests.js
+++ b/test/expect.tests.js
@@ -451,6 +451,55 @@
             });
         });
 
+        describe('toBeCloseTo', function(){
+            it('passes when within two decimal places by default', function() {
+                expect(0).toBeCloseTo(0);
+                expect(0).toBeCloseTo(0.001);
+            });
+            it('fails when not within two decimal places by default', function() {
+                var error;
+                try{
+                    expect(0).toBeCloseTo(0.01);
+                }catch(err){
+                    error = err;
+                }
+                if(error === undefined){
+                    throw new Error('Expected error was not thrown');
+                }
+                if (error.message !== 'expected 0 to be close to 0.01'){
+                    throw new Error('Expected error message is not correct: ' + error.message);
+                }
+            });
+            it('accepts an optional precision argument', function() {
+                expect(0).toBeCloseTo(0.1, 0);
+                expect(0).toBeCloseTo(0.0001, 3);
+            });
+            it('rounds expected values', function() {
+                expect(1.23).toBeCloseTo(1.229);
+                expect(1.23).toBeCloseTo(1.226);
+                expect(1.23).toBeCloseTo(1.225);
+                var error;
+                try{
+                    expect(1.23).toBeCloseTo(1.2249999);
+                }catch(err){
+                    error = err;
+                }
+                if(error === undefined){
+                    throw new Error('Expected error was not thrown');
+                }
+                expect(1.23).toBeCloseTo(1.234);
+            });
+            it('supports custom messages', function(){
+                try{
+                    expect(1).toBeCloseTo(2, undefined, 'A custom error');
+                }catch(err){
+                    if (err.message !== 'A custom error: expected 1 to be close to 2'){
+                        throw new Error('Expected error message is not correct: ' + err.message);
+                    }
+                }
+            });
+        });
+
         describe('not', function(){
             it('negates equal', function(){
                 expect(false).not.toEqual(true);


### PR DESCRIPTION
Jasmine comes with a matcher `toBeCloseTo`, used to compare floating point numbers.

I had to implement this matcher in a helper file in order to port the test suite of [Q-exact](https://github.com/fasttime/Q-exact) from Jasmine to Mocha, but this is actually the only matcher missing in expectations, so I'm issuing this pull request.

My implementation is similar to Jasmine's [toBeCloseTo.js](https://github.com/jasmine/jasmine/blob/master/src/core/matchers/toBeCloseTo.js). The test logic is also the same ([toBeCloseToSpec.js](https://github.com/jasmine/jasmine/blob/master/spec/core/matchers/toBeCloseToSpec.js)), plus the custom error message test case. I also tried to keep the style consistent with the rest of the code, but let me know if I there's anything that can be improved.