### PR TITLE
Improve .toMatch()

### DIFF
--- a/expectations.js
+++ b/expectations.js
@@ -280,6 +280,14 @@
     Expect.prototype.toMatch = function(regex, customMsg){
         var generateMessage = this.generateMessage(this.value, this.expr, 'to match', regex, customMsg);
 
+        if(typeof regex === 'string'){
+            regex = new RegExp(regex);
+        }
+
+        if(!regex.test){
+            throw new Error('unexpected object provided to Expect.toMatch: ' + JSON.stringify(regex) );
+        }
+
         if(regex.test(this.value)){
             return this.pass(generateMessage);
         }

--- a/test/expect.tests.js
+++ b/test/expect.tests.js
@@ -149,6 +149,20 @@
                     }
                 }
             });
+
+            it('can use a string as the match expression', function(){
+                expect('abc').toMatch('a');
+            });
+
+            it('throws if not called with a regex or string', function(){
+                try {
+                    expect('abc').toMatch({});
+                }catch(err){
+                    if(err.message !== 'unexpected object provided to Expect.toMatch: {}'){
+                        throw new Error('Expected error message is not correct: ' + err.message);
+                    }
+                }
+            });
         });
 
         describe('toBeTruthy', function(){


### PR DESCRIPTION
toMatch will now accept a string as well as a RegExp. It also throws
with a useful error if it is called with neither of the above.