### PR TITLE
Improved IE compatibility

### DIFF
--- a/expectations.js
+++ b/expectations.js
@@ -78,9 +78,6 @@
 
         if(typeof value === 'object' && stack.length < 10){
             if(value.toString() !== '[object Object]'){
-                if(value instanceof Error){
-                    return '[' + value + ']';
-                }
                 return '[' + value.toString() + ']';
             }
             if(isOnStack(value, stack)){

--- a/expectations.js
+++ b/expectations.js
@@ -3,7 +3,7 @@
     var AssertionError = function(options){
         this.message = options.message;
     };
-    AssertionError.prototype = Error.prototype;
+    AssertionError.prototype = Object.create(Error.prototype);
     AssertionError.prototype.toString = function(){
         return this.message;
     };
@@ -25,6 +25,16 @@
     var toString = Object.prototype.toString,
         hasOwnProperty = Object.prototype.hasOwnProperty;
 
+    // If a function has no name property (IE), get the name from its string representation.
+    function getFunctionName(fn){
+        var name = fn.name;
+        if (name === undefined){
+            var matches = /^\s*function\s+([\w$]+)/.exec(fn);
+            name = matches ? matches[1] : '';
+        }
+        return name;
+    }
+    
     function formatValue(value, ignoreUndefined, stack){
         stack = stack || [];
 
@@ -36,7 +46,7 @@
             return ignoreUndefined ? '' : 'undefined';
         }
         if(typeof value === 'function'){
-            return 'function ' + value.name + '(){}';
+            return 'function ' + getFunctionName(value) + '(){}';
         }
         if(typeof value === 'string'){
             return '"' + value + '"';
@@ -69,7 +79,7 @@
         if(typeof value === 'object' && stack.length < 10){
             if(value.toString() !== '[object Object]'){
                 if(value instanceof Error){
-                    return '[Error: ' + value.toString() + ']';
+                    return '[' + value + ']';
                 }
                 return '[' + value.toString() + ']';
             }

--- a/test/expect.tests.js
+++ b/test/expect.tests.js
@@ -685,7 +685,10 @@
                 try{
                     expect(new Date(Date.UTC(2012, 0, 1))).not.toBeDefined();
                 }catch(err){
-                    if(err.message !== 'expected [Date Sun, 01 Jan 2012 00:00:00 GMT] not to be defined'){
+                    // IE <= 10 uses the format "Date Sun, 1 Jan 2012 00:00:00 UTC"; all other browsers use
+                    // "Date Sun, 01 Jan 2012 00:00:00 GMT".
+                    if(err.message !== 'expected [Date Sun, 01 Jan 2012 00:00:00 GMT] not to be defined' &&
+                       err.message !== 'expected [Date Sun, 1 Jan 2012 00:00:00 UTC] not to be defined'){
                         throw new Error('Expected error message is not correct: ' + err.message);
                     }
                 }


### PR DESCRIPTION
I made a couple of fixes to make expectations pass all unit tests in Internet Explorer 9, 10, and 11.

The first commit adds a workaround to extract the function name in IE where functions have no name property. There is also a fix for AssertionError.prototype to make it a distinct object derived from Error.prototype, so overwriting AssertionError.prototype.toString no longer affects the way all other errors are converted into a string.

The second commit doesn't change any functionality, but allows IE 9 and 10 to pass a test case.

The last commit optimizes out some code that's become redundant after commit 1.