### PR TITLE
Fix issue where formatValue would error on some objects.

### DIFF
--- a/expectations.js
+++ b/expectations.js
@@ -34,7 +34,7 @@
         }
         return name;
     }
-    
+
     function formatValue(value, ignoreUndefined, stack){
         stack = stack || [];
 
@@ -77,7 +77,8 @@
         }
 
         if(typeof value === 'object' && stack.length < 10){
-            if(value.toString() !== '[object Object]'){
+
+            if(value.toString && value.toString() !== '[object Object]'){
                 return '[' + value.toString() + ']';
             }
             if(isOnStack(value, stack)){
@@ -88,7 +89,8 @@
                 return ['"', key, '": ', formatValue(value[key], false, stack.concat(value))].join('');
             }).join(', ') + '}';
         }
-        return value.toString();
+
+        return value.toString ? value.toString() : Object.prototype.toString.call(value);
     }
 
     // This function borrowed from underscore

--- a/test/expect.tests.js
+++ b/test/expect.tests.js
@@ -570,6 +570,18 @@
                     }
                 }
             });
+            it('can generate correct message for Object with null prototype', function(){
+                function Obj() {}
+                Obj.prototype = Object.create(null);
+                try{
+                    expect(new Obj()).not.toBeDefined();
+                }catch(err){
+                    if(err.message !== 'expected {} not to be defined'){
+                        console.log(err.message);
+                        throw new Error('Expected error message is not correct: ' + err.message);
+                    }
+                }
+            });
             it('can generate correct message for Errors', function(){
                 try{
                     expect(new Error('text')).not.toBeDefined();


### PR DESCRIPTION
In some circumstances an Object can be created without a prototype
(eg `Object.create(null)`). This type of Object would cause the
`formatValue` function to puke. I've fixed this by using
`Object.prototype.toString.call(value)` instead.