### PR TITLE
Add `toBeOfType` and `toBeOfInstance`

### DIFF
--- a/expectations.js
+++ b/expectations.js
@@ -364,6 +364,22 @@
         }
         this.fail(generateMessage);
     };
+    Expect.prototype.toBeOfType = function(type, customMsg){
+      var generateMessage = this.generateMessage(this.value, this.expr, 'to be of type', type, customMsg);
+
+      if(typeof this.value === type){
+          return this.pass(generateMessage);
+      }
+      this.fail(generateMessage);
+   };
+   Expect.prototype.toBeOfInstance = function(instance, customMsg){
+     var generateMessage = this.generateMessage(this.value, this.expr, 'to be instance of', instance.name, customMsg);
+
+     if(this.value instanceof instance){
+         return this.pass(generateMessage);
+     }
+     this.fail(generateMessage);
+   };
 
     Expect.prototype.pass = function(why){
         this.assertions.pass(why);

--- a/test/expect.tests.js
+++ b/test/expect.tests.js
@@ -514,6 +514,54 @@
             });
         });
 
+        describe('toBeOfType', function(){
+            it('can expect types to match', function(){
+               expect(123).toBeOfType('number');
+            });
+            it('can expect instances to not match', function(){
+               try{
+                   expect(123).toBeOfType('number');
+               }catch(err){
+                   if (err.message !== 'expected "abc" to be of type "number"'){
+                       throw new Error('Expected error message is not correct: ' + err.message);
+                   }
+               }
+            });
+            it('supports custom messages', function(){
+               try{
+                   expect('abc').toBeOfType('number', 'A custom error');
+               }catch(err){
+                   if (err.message !== 'A custom error: expected "abc" to be of type "number"'){
+                       throw new Error('Expected error message is not correct: ' + err.message);
+                   }
+               }
+            });
+        });
+
+        describe('toBeOfInstance', function(){
+            it('can expect types to match', function(){
+               expect([1, 2, 3]).toBeOfInstance(Array);
+            });
+            it('can expect types to not match', function(){
+               try{
+                   expect('abc').toBeOfInstance(Object);
+               }catch(err){
+                   if (err.message !== 'expected "abc" to be instance of "Object"'){
+                       throw new Error('Expected error message is not correct: ' + err.message);
+                   }
+               }
+            });
+            it('supports custom messages', function(){
+               try{
+                   expect('abc').toBeOfInstance(Object, 'A custom error');
+               }catch(err){
+                   if (err.message !== 'A custom error: expected "abc" to be instance of "Object"'){
+                       throw new Error('Expected error message is not correct: ' + err.message);
+                   }
+               }
+            });
+        });
+
         describe('not', function(){
             it('negates equal', function(){
                 expect(false).not.toEqual(true);


### PR DESCRIPTION
Often times one has expectations to check on instance of type of a parameter. These are usually written as in 

```js
expect([1, 2, 3] instanceof Array).toBeTruthy();
```

which gives a not very aligned error message with what the tester was trying to "expect".

Where as

```js
expect([1, 2, 3]).toBeOfType('array');
```

or 

```js
expect(SomeObject).toBeOfInstance(SomeOtherThing);
```

maybe makes more sense.