### PR TITLE
Fixed all TypedArray comparisons

### DIFF
--- a/expectations.js
+++ b/expectations.js
@@ -93,6 +93,18 @@
         return value.toString ? value.toString() : Object.prototype.toString.call(value);
     }
 
+	var arrayClassLookup = {
+		'[object Array]': true, 
+		'[object Int8Array]': true, 
+		'[object Uint8Array]': true, 
+		'[object Uint8ClampedArray]': true, 
+		'[object Int16Array]': true, 
+		'[object Uint16Array]': true,
+		'[object Int32Array]': true,
+		'[object Uint32Array]': true,
+		'[object Float32Array]': true,
+		'[object Float64Array]': true
+	}
     // This function borrowed from underscore
     function eq(a, b, stack) {
         /*jshint eqnull:true*/
@@ -140,7 +152,7 @@
         var size = 0,
             result = true;
         // Recursively compare objects and arrays.
-        if (className == '[object Array]' || className == '[object Uint8Array]') {
+        if (arrayClassLookup[className] === true) {
           // Compare array lengths to determine if a deep comparison is necessary.
           size = a.length;
           result = size == b.length;

--- a/test/expect.tests.js
+++ b/test/expect.tests.js
@@ -51,14 +51,85 @@
             it('equates undefined values and null', function(){
                 expect(undefined).toEqual(null);
             });
-            it('supports Uint8Array comparisons', function() {
-                var a = new Uint8Array([2, 3]);
-                var b = new Uint8Array([2, 3]);
-                var c = new Uint8Array([1, 2, 3]);
 
-                expect(b).toEqual(a);
-                expect(c.subarray(1)).toEqual(a);
-            })
+            if (typeof Uint8Array === "function") {
+                it('supports Uint8Array comparisons', function() {
+                    var a = new Uint8Array([2, 3]);
+                    var b = new Uint8Array([2, 3]);
+                    var c = new Uint8Array([1, 2, 3]);
+
+                    expect(b).toEqual(a);
+                    expect(c.subarray(1)).toEqual(a);
+                });
+                it('supports Int8Array comparisons', function() {
+                    var a = new Int8Array([-2, 3]);
+                    var b = new Int8Array([-2, 3]);
+                    var c = new Int8Array([1, -2, 3]);
+
+                    expect(b).toEqual(a);
+                    expect(c.subarray(1)).toEqual(a);
+                });
+                it('supports Uint16Array comparisons', function() {
+                    var a = new Uint16Array([2000, 3000]);
+                    var b = new Uint16Array([2000, 3000]);
+                    var c = new Uint16Array([1000, 2000, 3000]);
+
+                    expect(b).toEqual(a);
+                    expect(c.subarray(1)).toEqual(a);
+                });
+                it('supports Int16Array comparisons', function() {
+                    var a = new Int16Array([-2000, 3000]);
+                    var b = new Int16Array([-2000, 3000]);
+                    var c = new Int16Array([1000, -2000, 3000]);
+
+                    expect(b).toEqual(a);
+                    expect(c.subarray(1)).toEqual(a);
+                });
+                it('supports Uint32Array comparisons', function() {
+                    var a = new Uint32Array([2000000, 3000000]);
+                    var b = new Uint32Array([2000000, 3000000]);
+                    var c = new Uint32Array([1000000, 2000000, 3000000]);
+
+                    expect(b).toEqual(a);
+                    expect(c.subarray(1)).toEqual(a);
+                });
+                it('supports Int32Array comparisons', function() {
+                    var a = new Int32Array([-2000000, 3000000]);
+                    var b = new Int32Array([-2000000, 3000000]);
+                    var c = new Int32Array([1000000, -2000000, 3000000]);
+
+                    expect(b).toEqual(a);
+                    expect(c.subarray(1)).toEqual(a);
+                });
+                it('supports Float32Array comparisons', function() {
+                    var a = new Float32Array([-2000000.2222, 3000000.3333]);
+                    var b = new Float32Array([-2000000.2222, 3000000.3333]);
+                    var c = new Float32Array([1000000.1111, -2000000.2222, 3000000.3333]);
+
+                    expect(b).toEqual(a);
+                    expect(c.subarray(1)).toEqual(a);
+                });
+                it('supports Float64Array comparisons', function() {
+                    var a = new Float64Array([-2000000.2222 * 1000000, 3000000.3333 * 1000000]);
+                    var b = new Float64Array([-2000000.2222 * 1000000, 3000000.3333 * 1000000]);
+                    var c = new Float64Array([1000000.1111 * 1000000, -2000000.2222 * 1000000, 3000000.3333 * 1000000]);
+
+                    expect(b).toEqual(a);
+                    expect(c.subarray(1)).toEqual(a);
+                });
+            }
+
+            if (typeof Uint8ClampedArray === "function") {
+                it('supports Uint8ClampedArray comparisons', function() {
+                    var a = new Uint8ClampedArray([2, 3]);
+                    var b = new Uint8ClampedArray([2, 3]);
+                    var c = new Uint8ClampedArray([1, 2, 3]);
+
+                    expect(b).toEqual(a);
+                    expect(c.subarray(1)).toEqual(a);
+                });
+            }
+
             it('Can expect a more complex object to equal another complex object', function(){
                 var obj1 = {"name":"someData", array: [1,2,3,{c:"hello"}], val2: 'ing', val1: 'test'};
                 var obj2 = {"name":"someData", array: [1,2,3,{c:"hello"}], val1: 'test', val2: 'ing'};


### PR DESCRIPTION
Several months ago I reported an [issue with typed array comparisons](https://github.com/spmason/expectations/issues/24) in Android Browser v4.0-4.3. 
The issue was fixed, though only for `Uint8Array`s. 

However, it turns out this issue also happens in latest Phantomjs, this causes 11 tests to fail in one of my projects. Since the patched version wasn't updated to npm there isn't really a way to use it in node (except manually patching the file every time or forking the assertion library). This makes it very hard to run tests in services like Travis CI.

I fixed the issue for all typed arrays, and wrote individual tests for each different case (I tried to use number ranges appropriate for the target numeric type). 

I conditioned the tests so that they would only be run if the run-time supports typed arrays. A special case is [`Uint8ClampedArray`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Uint8ClampedArray) for which support was only introduced as a [security patch KB2929437 to IE11](https://www.microsoft.com/en-us/download/details.aspx?id=42463), and wasn't supported on earlier Android Browser version. It is detected and tested separately.

I have verified all the tests pass in latest Chrome, Firefox and Edge, IE11, IE10 (in a VM), Safari 5.1.4 for Windows, Android 4.2.2, 4.4.2, 5.1.1, 6.0.0, 7.0.0 (through the emulator), 

I would highly appreciate your time in reviewing this patch. It is critical for the projects I am developing. Please let me know if there is anything else needed.