### PR TITLE
updated eq function constructor comparison to allow comparison of two…

### DIFF
--- a/expectations.js
+++ b/expectations.js
@@ -164,8 +164,14 @@
                 }
             }
         } else {
-            // Objects with different constructors are not equivalent.
-            if ('constructor' in a != 'constructor' in b || a.constructor != b.constructor) return false;
+            // Objects with different constructors are not equivalent, but `Object`s or `Array`s
+            // from different frames are.
+            var aCtor = a.constructor, bCtor = b.constructor;
+            if (aCtor !== bCtor
+                    && !(typeof aCtor === 'function' && aCtor instanceof aCtor && typeof bCtor === 'function' && bCtor instanceof bCtor)
+                    && ('constructor' in a && 'constructor' in b)) {
+                return false;
+            }
             // Deep compare objects.
             for (var key in a) {
                 if (hasOwnProperty.call(a, key) && a[key] !== undefined) {

--- a/test/expect.tests.js
+++ b/test/expect.tests.js
@@ -154,6 +154,10 @@
                     }
                 }
             });
+
+            it('Can expect objects to be equal if only one has a constructor property', function(){
+                expect(Object.create(null)).toEqual({});
+            });
         });
 
         describe('toNotEqual', function(){


### PR DESCRIPTION
… objects of which one has no constructor

* this was addressed in underscore here: https://github.com/jashkenas/underscore/issues/1314
* objects created with Object.create(null) have no constructor property but we are comparing properties so should not fail on undefined constructor properties